### PR TITLE
Hide youtube logo from hero video

### DIFF
--- a/src/components/Hero/styles.js
+++ b/src/components/Hero/styles.js
@@ -5,16 +5,14 @@ export const HeroContainer = styled.div`
 
   width: 100%;
   height: 100vh;
-  /* position: fixed; */
-  /* top: 0; */
+
   overflow: hidden;
-  /* z-index: -1000; */
 
   position: relative;
 
   iframe {
     width: calc(100% + 96px);
-    height: calc(100% + 96px);
+    height: calc(100% + 116px);
 
     overflow: hidden;
     position: absolute;


### PR DESCRIPTION
hid the youtube logo that was showing in the hero video on the bottom right corner of the screen.